### PR TITLE
Fix skipped episode number

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -21,7 +21,7 @@ func missingEpisodeString(episodes []*Episode) string {
 
 	result := fmt.Sprintf("Episodes %d", episodes[0].Number())
 
-	for _, episode := range episodes[1 : l-2] {
+	for _, episode := range episodes[1 : l-1] {
 		result += fmt.Sprintf(", %d", episode.Number())
 	}
 


### PR DESCRIPTION
For whatever reason the list skipped the one before last episode originally. Best guess (without learning GoLang) is the range starts from 1 instead of 0, therefore the lenght of the range changes with n-1.